### PR TITLE
Revert "poplar: extract: Don't add Sony camera service to camera-daem…

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -80,10 +80,4 @@ fix_product_path product/etc/permissions/lpa.xml
 fix_product_path product/etc/permissions/qcrilhook.xml
 fix_product_path product/etc/permissions/telephonyservice.xml
 
-#
-# Don't add Sony camera service to camera-daemon tasks
-#
-
-sed -i 's/\/dev\/cpuset\/camera-daemon\/tasks //g' "${DEVICE_ROOT}"/vendor/etc/init/vendor.somc.hardware.camera.provider@1.0-service.rc
-
 "${MY_DIR}"/setup-makefiles.sh


### PR DESCRIPTION
…on tasks"

Turns out, this was not the problem with stuck cpu frequencies. We can actually make use of this now.

This reverts commit 6e3e6a3fcf54f0c46729f3080609b41583942513.